### PR TITLE
Bump rethinkdb version to 1.12.4

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 #
 
 default['rethinkdb']['install_method'] = 'package'
-default['rethinkdb']['version'] = '1.7.1'
+default['rethinkdb']['version'] = '1.12.4'
 default['rethinkdb']['make_threads'] = node['cpu'] ? node['cpu']['total'].to_i : 1
 default['rethinkdb']['src_url'] = "http://download.rethinkdb.com/dist"
 default['rethinkdb']['dir'] = "/usr/local"

--- a/recipes/start.rb
+++ b/recipes/start.rb
@@ -34,7 +34,7 @@ rethinkdb_servers.each do |server|
   end
 end
 
-# merge curreny node
+# merge current node
 servers_ips = servers_ips.to_set()
 node.rethinkdb.instances.each do |instance|
   clusterPort = (instance.clusterPort + instance.portOffset).to_s()


### PR DESCRIPTION
RethinkDB Version 1.7.1 is unavailable.
